### PR TITLE
Fetch jet data

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,15 +1,22 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
-
+import { useDispatch } from 'react-redux';
 import Nav from './components/nav/Nav';
 import ReservationPage from './pages/reservation/ReservationPage';
 import Main from './pages/main/Main';
 import SignupForm from './components/user/SignupForm';
 import LoginForm from './components/user/LoginForm';
 import AddJet from './pages/addjet/AddJet';
+import { getJetsThunk } from './redux/jets/jetSlice';
 import './App.css';
 
 function App() {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(getJetsThunk());
+  }, [dispatch]);
+
   return (
     <Router>
       <Nav />

--- a/src/components/jet/AddJetForm.js
+++ b/src/components/jet/AddJetForm.js
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import { TextField, Button } from '@mui/material';
+import { useDispatch } from 'react-redux';
 import { addNewJet } from '../../redux/jets/jetAPI';
+import { addJet } from '../../redux/jets/jetSlice';
 
 const AddJetForm = () => {
   const [name, setName] = useState('');
@@ -10,6 +12,8 @@ const AddJetForm = () => {
   const [image, setImage] = useState('');
   const [pricePerDay, setPricePerDay] = useState('');
   const [financeFee, setFinanceFee] = useState('');
+
+  const dispatch = useDispatch();
 
   const handleNewJet = async (e) => {
     e.preventDefault();
@@ -23,7 +27,8 @@ const AddJetForm = () => {
     data.append('financeFee', financeFee);
     data.append('image', image);
     const res = await addNewJet(data);
-    console.log(res);
+    dispatch(addJet(res.jet));
+    console.log(res.jet, 'test');
   };
 
   return (

--- a/src/components/jet/Jet.js
+++ b/src/components/jet/Jet.js
@@ -8,12 +8,18 @@ import './Jet.scss';
 import * as FaIcons from 'react-icons/fa';
 
 function MainJet(props) {
-  const { name, description } = props;
+  const { name, description, image } = props;
 
   return (
     <div className="jet-container">
       <div>
-        <img src="https://via.placeholder.com/150x150" alt="Jet" />
+        <img
+          src={image}
+          alt={name}
+          className="jet-image"
+          height="150px"
+          width="250px"
+        />
       </div>
       <div>
         <h2>{name}</h2>
@@ -37,6 +43,7 @@ function MainJet(props) {
 MainJet.propTypes = {
   name: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
+  image: PropTypes.string.isRequired,
 };
 
 export default MainJet;

--- a/src/components/jet/Jet.scss
+++ b/src/components/jet/Jet.scss
@@ -5,7 +5,6 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
-  padding: 1rem;
   border-radius: 0.5rem;
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,9 +9,7 @@ const container = document.getElementById('root');
 const root = createRoot(container);
 
 root.render(
-  <React.StrictMode>
-    <Provider store={store}>
-      <App />
-    </Provider>
-  </React.StrictMode>,
+  <Provider store={store}>
+    <App />
+  </Provider>,
 );

--- a/src/pages/main/Main.js
+++ b/src/pages/main/Main.js
@@ -1,20 +1,14 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import React, { useEffect } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import React from 'react';
+import { useSelector } from 'react-redux';
 import Slider from 'react-slick';
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 import Jet from '../../components/jet/Jet';
 import './main.scss';
-import { getJetsThunk } from '../../redux/jets/jetSlice';
 
 function Main() {
   const { jets } = useSelector((state) => state.jets);
-  const dispatch = useDispatch();
-
-  useEffect(() => {
-    dispatch(getJetsThunk());
-  }, [dispatch]);
 
   const sliderSettings = {
     dots: true,
@@ -47,6 +41,7 @@ function Main() {
             <Jet
               name={data.name}
               description={data.description}
+              image={data.image}
               key={data.id}
             />
           ))}

--- a/src/pages/main/Main.js
+++ b/src/pages/main/Main.js
@@ -1,16 +1,22 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import React from 'react';
-// import { useSelector } from 'react-redux';
+import React, { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import Slider from 'react-slick';
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 import Jet from '../../components/jet/Jet';
 import './main.scss';
+import { getJetsThunk } from '../../redux/jets/jetSlice';
 
 function Main() {
-  // const { jets } = useSelector((state) => state.jets);
+  const { jets } = useSelector((state) => state.jets);
+  const dispatch = useDispatch();
 
-  const settings = {
+  useEffect(() => {
+    dispatch(getJetsThunk());
+  }, [dispatch]);
+
+  const sliderSettings = {
     dots: true,
     infinite: true,
     speed: 500,
@@ -29,29 +35,6 @@ function Main() {
     ],
   };
 
-  const dummyData = [
-    {
-      name: 'Jet 1',
-      description: 'Lorem, ipsum dolor sit amet consectetur adipisicing elit. Voluptas ullam voluptatibus deserunt',
-      key: 'jet1',
-    },
-    {
-      name: 'Jet 2',
-      description: 'Lorem, ipsum dolor sit amet consectetur adipisicing elit. Voluptas ullam voluptatibus deserunt',
-      key: 'jet2',
-    },
-    {
-      name: 'Jet 3',
-      description: 'Lorem, ipsum dolor sit amet consectetur adipisicing elit. Voluptas ullam voluptatibus deserunt',
-      key: 'jet3',
-    },
-    {
-      name: 'Jet 4',
-      description: 'Lorem, ipsum dolor sit amet consectetur adipisicing elit. Voluptas ullam voluptatibus deserunt',
-      key: 'jet4',
-    },
-  ];
-
   return (
     <div className="home">
       <div className="home__title">
@@ -59,12 +42,12 @@ function Main() {
         <p>Please select a Jet Model</p>
       </div>
       <ul className="home__card-container">
-        <Slider {...settings}>
-          {dummyData.map((data) => (
+        <Slider {...sliderSettings}>
+          {jets.map((data) => (
             <Jet
               name={data.name}
               description={data.description}
-              key={data.key}
+              key={data.id}
             />
           ))}
         </Slider>

--- a/src/redux/jets/jetAPI.js
+++ b/src/redux/jets/jetAPI.js
@@ -14,7 +14,7 @@ export const addNewJet = async (jet) => {
 
 export const getJets = async () => {
   try {
-    const res = await axios.get(`${JETAPPI}/`);
+    const res = await axios.get(`${JETAPPI}/jets`);
     return res.data;
   } catch (err) {
     throw new Error('err');

--- a/src/redux/jets/jetSlice.js
+++ b/src/redux/jets/jetSlice.js
@@ -1,7 +1,7 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import { getJets } from './jetAPI';
 
-const getJetsThunk = createAsyncThunk('jets/getJets', async () => {
+export const getJetsThunk = createAsyncThunk('jets/getJets', async () => {
   const response = await getJets();
   return response;
 });

--- a/src/redux/jets/jetSlice.js
+++ b/src/redux/jets/jetSlice.js
@@ -11,6 +11,11 @@ const jetSlice = createSlice({
   initialState: {
     jets: [],
   },
+  reducers: {
+    addJet: (state, action) => {
+      state.jets.push(action.payload);
+    },
+  },
   extraReducers: {
     [getJetsThunk.pending]: (state) => ({
       ...state,
@@ -27,5 +32,5 @@ const jetSlice = createSlice({
     }),
   },
 });
-
+export const { addJet } = jetSlice.actions;
 export default jetSlice.reducer;


### PR DESCRIPTION
#  We  @worashf and  @mikemtzp  have done the following tasks. :hand: 

1. Fetched all jets data when the app started :heavy_check_mark: 
2. Moved the dispatch get jets data thunk method to app.js to remove  dispatching again and again when the user navigates between different routes :heavy_check_mark: 
3. Select the jets data from the Redux store and render it on the home page :heavy_check_mark: 
4. Added add new jet reducer action  and dispatch it after creating new jet to update the store :heavy_check_mark:
 
## Kanban board issue 
![image](https://user-images.githubusercontent.com/66208963/198305510-c654cd03-3aa5-4f88-87ad-5aae079f7b66.png)
