### PR TITLE
Delete jet

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import Main from './pages/main/Main';
 import SignupForm from './components/user/SignupForm';
 import LoginForm from './components/user/LoginForm';
 import AddJet from './pages/addjet/AddJet';
+import DeleteJetPage from './pages/deleteJet/DeleteJetPage';
 import { getJetsThunk } from './redux/jets/jetSlice';
 import { getReservationsThunk } from './redux/reservation/reservationSlice';
 import './App.css';
@@ -31,6 +32,7 @@ function App() {
         <Route path="/reservation" element={<ReservationPage />} />
         <Route path="/myreservations" element={<MyReservation />} />
         <Route path="/add-jet" element={<AddJet />} />
+        <Route path="/delete-jet" element={<DeleteJetPage />} />
       </Routes>
     </Router>
   );

--- a/src/app/store.js
+++ b/src/app/store.js
@@ -1,6 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit';
 import jetSlice from '../redux/jets/jetSlice';
-// import myReservationsReducer from '../redux/myReservations/myReservationsReducer';
 import reservationSlice from '../redux/reservation/reservationSlice';
 
 export const store = configureStore({

--- a/src/components/jet/DeleteJet.js
+++ b/src/components/jet/DeleteJet.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { deleteJet } from '../../redux/jets/jetAPI';
 import { getJetsThunk } from '../../redux/jets/jetSlice';
@@ -9,6 +10,7 @@ function DeleteJet(props) {
     name, description, image, id,
   } = props;
   const dispatch = useDispatch();
+  const navigate = useNavigate();
 
   const handleDelete = async (e, jetId) => {
     e.preventDefault();
@@ -16,15 +18,15 @@ function DeleteJet(props) {
     const jet = { id: jetId };
     await deleteJet(jet);
     dispatch(getJetsThunk());
+    navigate('/');
   };
 
   return (
-    <div className="jet-container">
+    <div>
       <div>
         <img
           src={image}
           alt={name}
-          className="jet-image"
           height="150px"
           width="250px"
         />
@@ -33,7 +35,7 @@ function DeleteJet(props) {
         <h2>{name}</h2>
         <p>{description}</p>
       </div>
-      <div className="social-container">
+      <div>
         <button type="button" onClick={(e) => handleDelete(e, id)}>Delete</button>
       </div>
     </div>

--- a/src/components/jet/DeleteJet.js
+++ b/src/components/jet/DeleteJet.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import PropTypes from 'prop-types';
+import { deleteJet } from '../../redux/jets/jetAPI';
+import { getJetsThunk } from '../../redux/jets/jetSlice';
+
+function DeleteJet(props) {
+  const {
+    name, description, image, id,
+  } = props;
+  const dispatch = useDispatch();
+
+  const handleDelete = async (e, jetId) => {
+    e.preventDefault();
+
+    const jet = { id: jetId };
+    await deleteJet(jet);
+    dispatch(getJetsThunk());
+  };
+
+  return (
+    <div className="jet-container">
+      <div>
+        <img
+          src={image}
+          alt={name}
+          className="jet-image"
+          height="150px"
+          width="250px"
+        />
+      </div>
+      <div>
+        <h2>{name}</h2>
+        <p>{description}</p>
+      </div>
+      <div className="social-container">
+        <button type="button" onClick={(e) => handleDelete(e, id)}>Delete</button>
+      </div>
+    </div>
+  );
+}
+
+DeleteJet.propTypes = {
+  name: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+  image: PropTypes.string.isRequired,
+  id: PropTypes.number.isRequired,
+};
+
+export default DeleteJet;

--- a/src/components/nav/SidebarData.js
+++ b/src/components/nav/SidebarData.js
@@ -36,7 +36,7 @@ const SidebarData = [
   },
   {
     title: 'Delete Jet',
-    path: '/deletejet',
+    path: '/delete-jet',
     icon: <MdIcons.MdAirplanemodeInactive />,
     cName: 'nav-text',
     key: 'deleteJet',

--- a/src/pages/deleteJet/DeleteJetPage.js
+++ b/src/pages/deleteJet/DeleteJetPage.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import DeleteJet from '../../components/jet/DeleteJet';
+
+function DeleteJetPage() {
+  const { jets } = useSelector((state) => state.jets);
+
+  return (
+    <>
+      <h1>Delete Jet Page</h1>
+      {jets.map((jet) => (
+        <DeleteJet
+          name={jet.name}
+          description={jet.description}
+          image={jet.image}
+          id={jet.id}
+          key={jet.id}
+        />
+      ))}
+    </>
+  );
+}
+
+export default DeleteJetPage;

--- a/src/pages/main/Main.js
+++ b/src/pages/main/Main.js
@@ -31,7 +31,7 @@ function Main() {
         },
       },
       {
-        breakpoint: 400,
+        breakpoint: 450,
         settings: {
           slidesToShow: 1,
           slidesToScroll: 1,

--- a/src/redux/jets/jetAPI.js
+++ b/src/redux/jets/jetAPI.js
@@ -20,3 +20,12 @@ export const getJets = async () => {
     throw new Error('err');
   }
 };
+
+export const deleteJet = async (jet) => {
+  try {
+    const response = await axios.delete(`${api}/delete-jet`, { params: jet });
+    return response;
+  } catch (err) {
+    throw new Error(err);
+  }
+};


### PR DESCRIPTION
# In this new Pull Request I'm adding the following features:
- Create a new DeleteJetePage component and route it in App.
- Create a new DeleteJet component with the basic structure of the jet card and the button to delete.
- When the user clicks the delete button, the jet is deleted and redirects to the main page.

![Captura de Pantalla 2022-10-28 a la(s) 10 24 08](https://user-images.githubusercontent.com/36968008/198610206-58cebbd4-1a37-4671-98cc-c85a98270a1e.png)
